### PR TITLE
Fix onPlayBackSeek() backtraces

### DIFF
--- a/plugin.service.mqtt/service.py
+++ b/plugin.service.mqtt/service.py
@@ -178,10 +178,10 @@ class MQTTPlayer(xbmc.Player):
     def onPlayBackStopped(self):
         setplaystate(0,"stopped")
 
-    def onPlayBackSeek(self):
+    def onPlayBackSeek(self, time, seek_offset):
         publishprogress()
 
-    def onPlayBackSeekChapter(self):
+    def onPlayBackSeekChapter(self, chapter):
         publishprogress()
 
     def onPlayBackSpeedChanged(self,speed):


### PR DESCRIPTION
Hi there and thanks for maintaining this fork!  I've been using it with Kodi Matrix for a couple of weeks and only found one minor issue.  Over on the forums there's now a pointer to this repo: https://forum.kodi.tv/showthread.php?tid=222109

The issue I found is: if I play a video and then seek by clicking the progress bar in the web UI, I see this error in kodi.log:

    EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
     - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
    Error Type: <class 'TypeError'>
    Error Contents: onPlayBackSeek() takes 1 positional argument but 3 were given
    TypeError: onPlayBackSeek() takes 1 positional argument but 3 were given
    -->End of Python script error report<--

The supplied commit fixes this by correcting the function argument list.